### PR TITLE
Use React.Component instead of Component

### DIFF
--- a/React.14/Basic/ui-src/components/app.ctrl.js
+++ b/React.14/Basic/ui-src/components/app.ctrl.js
@@ -1,11 +1,11 @@
-import React, {Component} from 'react';
+import React from 'react';
 
 let AppCtrlSty = {
 	height: '100%',
 	padding: '0 10px 0 0'
 }
 
-export default class AppCtrl extends Component {
+export default class AppCtrl extends React.Component {
 	render() {
 		return (
 			<div id='AppCtrlSty' style={AppCtrlSty}>


### PR DESCRIPTION
Hey calitek!

This is great!

First thing that comes to mind is switching out the bare `component` with `React.Component` for the sake of readability.

Let me know what you think.
